### PR TITLE
Add endpoint for checking internet connectivity

### DIFF
--- a/src/linguaweb_api/routers/health/controller.py
+++ b/src/linguaweb_api/routers/health/controller.py
@@ -1,5 +1,18 @@
 """Controller to assess the health of the services."""
+import fastapi
+import requests
+from fastapi import status
 
 
-async def get_api_health() -> None:
+def get_api_health() -> None:
     """Returns the health of the API."""
+
+
+def get_internet_connectivity() -> None:
+    """Checks the internet connectivity of the API."""
+    response = requests.get("https://www.google.com", timeout=5)
+    if response.status_code != status.HTTP_200_OK:
+        raise fastapi.HTTPException(
+            status_code=response.status_code,
+            detail="Internet connectivity check failed.",
+        )

--- a/src/linguaweb_api/routers/health/views.py
+++ b/src/linguaweb_api/routers/health/views.py
@@ -27,4 +27,20 @@ router = fastapi.APIRouter(prefix="/health", tags=["health"])
 async def get_health() -> None:
     """Returns the health of the API."""
     logger.debug("Checking health.")
-    return await controller.get_api_health()
+    controller.get_api_health()
+
+
+@router.get(
+    "/connectivity",
+    status_code=fastapi.status.HTTP_200_OK,
+    summary="Checks the internet connectivity of the API.",
+    description=(
+        "Checks the internet connectivity of the API. This will return 200 if the "
+        "API can connect to the internet, any other response is indicative of a "
+        "serious issue."
+    ),
+)
+async def get_connectivity() -> None:
+    """Checks the internet connectivity of the API."""
+    logger.debug("Checking connectivity.")
+    controller.get_internet_connectivity()


### PR DESCRIPTION
This pull request adds a new endpoint to the API that allows checking the internet connectivity. The endpoint is `/connectivity` and returns a 200 status code if the API can connect to the internet. Any other response indicates a serious issue.