### PR TITLE
Add API key support and authentication

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ env:
   LWAPI_OPENAI_API_KEY: fake_key
   LWAPI_S3_ACCESS_KEY: fake_key
   LWAPI_S3_SECRET_KEY: fake_key
+  LWAPI_API_KEY: test
 
 jobs:
   tests:

--- a/src/linguaweb_api/core/config.py
+++ b/src/linguaweb_api/core/config.py
@@ -73,6 +73,11 @@ class Settings(pydantic_settings.BaseSettings):  # type: ignore[valid-type, misc
         json_schema_extra={"env": "LOGGER_VERBOSITY"},
     )
 
+    API_KEY: pydantic.SecretStr = pydantic.Field(
+        ...,
+        json_schema_extra={"env": "API_KEY"},
+    )
+
     ENVIRONMENT: str = pydantic.Field(
         "development",
         json_schema_extra={"env": "ENVIRONMENT"},

--- a/src/linguaweb_api/core/security.py
+++ b/src/linguaweb_api/core/security.py
@@ -1,0 +1,30 @@
+"""Security module for the CTK API."""
+import fastapi
+from fastapi import security, status
+
+from linguaweb_api.core import config
+
+settings = config.get_settings()
+API_KEY = settings.API_KEY
+
+
+def check_api_key(
+    api_key_header: str = fastapi.Security(security.APIKeyHeader(name="x-api-key")),
+) -> None:
+    """Checks the validity of the API key provided in the API key header.
+
+    At present, only a single API key is supported and is stored in the environment.
+
+    Args:
+        api_key_header: The API key provided in the API key header.
+
+    Raises:
+        fastapi.HTTPException: 401 If the API key is invalid or missing.
+
+    """
+    if api_key_header == API_KEY.get_secret_value():
+        return
+    raise fastapi.HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or missing API Key.",
+    )

--- a/src/linguaweb_api/routers/admin/views.py
+++ b/src/linguaweb_api/routers/admin/views.py
@@ -5,7 +5,7 @@ import fastapi
 from fastapi import status
 from sqlalchemy import orm
 
-from linguaweb_api.core import config, models
+from linguaweb_api.core import config, models, security
 from linguaweb_api.microservices import s3, sql
 from linguaweb_api.routers.admin import controller, schemas
 
@@ -14,7 +14,11 @@ LOGGER_NAME = settings.LOGGER_NAME
 
 logger = logging.getLogger(LOGGER_NAME)
 
-router = fastapi.APIRouter(prefix="/admin", tags=["admin"])
+router = fastapi.APIRouter(
+    prefix="/admin",
+    tags=["admin"],
+    dependencies=[fastapi.Depends(security.check_api_key)],
+)
 
 
 @router.post(

--- a/tests/.test.env
+++ b/tests/.test.env
@@ -2,3 +2,4 @@ LWAPI_OPENAI_API_KEY=fake_key
 LWAPI_S3_ACCESS_KEY=fake_key
 LWAPI_S3_SECRET_KEY=fake_key
 LWAPI_SQLITE_FILE=tests/test.sqlite
+LWAPI_API_KEY=test

--- a/tests/endpoint/test_admin.py
+++ b/tests/endpoint/test_admin.py
@@ -37,12 +37,26 @@ def _mock_services(mocker: pytest_mock.MockerFixture) -> Generator[None, None, N
         yield
 
 
+def test_add_word_no_auth(
+    client: testclient.TestClient,
+    endpoints: conftest.Endpoints,
+) -> None:
+    """Tests the add word endpoint without authentication."""
+    response = client.post(endpoints.POST_ADD_WORD, data={"word": "test_word"})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
 def test_add_word(
     client: testclient.TestClient,
     endpoints: conftest.Endpoints,
 ) -> None:
     """Tests the add word endpoint."""
-    response = client.post(endpoints.POST_ADD_WORD, data={"word": "test_word"})
+    response = client.post(
+        endpoints.POST_ADD_WORD,
+        data={"word": "test_word"},
+        headers={"x-api-key": "test"},
+    )
     expected_keys = {
         "id",
         "synonyms",
@@ -62,7 +76,11 @@ def test_add_word_already_exists(
     endpoints: conftest.Endpoints,
 ) -> None:
     """Tests the add word endpoint when the word already exists."""
-    client.post(endpoints.POST_ADD_WORD, data={"word": "test_word"})
+    client.post(
+        endpoints.POST_ADD_WORD,
+        data={"word": "test_word"},
+        headers={"x-api-key": "test"},
+    )
     expected_keys = {
         "id",
         "synonyms",
@@ -73,10 +91,24 @@ def test_add_word_already_exists(
         "language",
     }
 
-    response = client.post(endpoints.POST_ADD_WORD, data={"word": "test_word"})
+    response = client.post(
+        endpoints.POST_ADD_WORD,
+        data={"word": "test_word"},
+        headers={"x-api-key": "test"},
+    )
 
     assert response.status_code == status.HTTP_201_CREATED
     assert set(response.json().keys()) == expected_keys
+
+
+def test_add_preset_words_no_auth(
+    client: testclient.TestClient,
+    endpoints: conftest.Endpoints,
+) -> None:
+    """Tests the add preset words endpoint without authentication."""
+    response = client.post(endpoints.POST_ADD_PRESET_WORDS)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_add_preset_words(
@@ -99,6 +131,7 @@ def test_add_preset_words(
     response = client.post(
         endpoints.POST_ADD_PRESET_WORDS,
         data={"max_words": str(max_words)},
+        headers={"x-api-key": "test"},
     )
 
     assert response.status_code == status.HTTP_201_CREATED


### PR DESCRIPTION
This pull request adds API key support and authentication to the project. It includes changes to the settings file, the security module, and the admin router. The API key is stored in the environment and is checked for validity in the API key header. It also includes tests for the add word and add preset words endpoints, both with and without authentication.